### PR TITLE
Changes to build on Debian 10 (buster)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ if(XOR_TOOL_INC)
   endif()
 endif()
 
-install(TARGETS radio_tool)
+install(TARGETS radio_tool RUNTIME DESTINATION bin)
 
 set(CPACK_PROJECT_NAME ${PROJECT_NAME})
 set(CPACK_PROJECT_VERSION ${PROJECT_VERSION})

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Otherwise you can use the instructions below to build
 Dependencies Linux (Ubuntu/Debian):
 
 ```
-sudo apt install libusb-1.0-0-dev cmake gcc
+sudo apt install libusb-1.0-0-dev cmake gcc g++ pkg-config
 ```
 
 Dependencies Mac:

--- a/include/radio_tool/util/flash.hpp
+++ b/include/radio_tool/util/flash.hpp
@@ -116,7 +116,7 @@ namespace radio_tool::flash
         /**
          * Executes a function, sector aligned over a range of bytes for a give map
          */
-        static constexpr auto AlignedContiguousMemoryOp(const FlashMap& map, const uint32_t& start, const uint32_t& end, 
+        static auto AlignedContiguousMemoryOp(const FlashMap& map, const uint32_t& start, const uint32_t& end,
             const std::function<void(const uint32_t&, const uint32_t&, const FlashSector&)>& fnOp) -> void 
         {
             for (auto addr = start; addr < end;)


### PR DESCRIPTION
I'm not confident of the C++ changes especially, but this is what I had to change to get `radio_tool` to build on Debian 10 (buster). The error I had was:

```
In file included from /home/andrew/radio_tool/src/tyt_radio.cpp:20:
/home/andrew/radio_tool/include/radio_tool/util/flash.hpp: In static member function ‘static constexpr void radio_tool::flash::FlashUtil::AlignedContiguousMemoryOp(const FlashMap&, const uint32_t&, const uint32_t&, const std::function<void(const unsigned int&, const unsigned int&, const radio_tool::flash::FlashSector&)>&)’:
/home/andrew/radio_tool/include/radio_tool/util/flash.hpp:124:80: error: call to non-‘constexpr’ function ‘static std::optional<const radio_tool::flash::FlashSector> radio_tool::flash::FlashUtil::GetSector(const FlashMap&, const uint32_t&)’
                 if(const auto& sec_info = flash::FlashUtil::GetSector(map, addr))
                                                                                ^
```