### PR TITLE
Fix bug in Ailunce HD1 flashing protocol

### DIFF
--- a/src/ailunce_radio.cpp
+++ b/src/ailunce_radio.cpp
@@ -22,6 +22,7 @@
 #include <thread>
 
 #ifdef _WIN32
+#define B57600 57600
 #include <Windows.h>
 #include <io.h>
 #include <iostream>
@@ -35,6 +36,7 @@
 
 #else
 #include <unistd.h>
+#include <termios.h>
 #endif
 
 using namespace radio_tool::radio;
@@ -51,7 +53,8 @@ auto AilunceRadio::WriteFirmware(const std::string &file) const -> void
 
     //XOR raw binary data before sending
     fw.Encrypt();
-
+    
+    device.SetInterfaceAttribs(B57600, 0);
     auto fd = device.GetFD();
     // send 1 to start firmware upgrade
 #ifdef _WIN32
@@ -62,7 +65,6 @@ auto AilunceRadio::WriteFirmware(const std::string &file) const -> void
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
     auto r = fw.GetDataSegments()[0];
-    device.SetInterfaceAttribs(57600, 0);
     device.Write(r.data);
 }
 

--- a/src/fymodem.c
+++ b/src/fymodem.c
@@ -51,7 +51,7 @@
 /* error logging function */
 #define YM_ERR(fmt, ...) do { printf(fmt, __VA_ARGS__); } while(0)
 
-FILE* global_fd = 0;
+int global_fd = 0;
 
 char __ym_getchar(int timeout_ms)
 {


### PR DESCRIPTION
The baud rate for the serial port was being set only after the first
sent byte, this messed up the flashing command sent to the radio and
resulted in random flashing errors.