### PR TITLE
Add support for Yaesu FT-70D

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ endif()
 set(ALL_SRC 
     src/radio_tool.cpp
     src/dfu.cpp
+    src/h8sx.cpp
     src/radio_factory.cpp
     src/usb_radio_factory.cpp
     src/serial_radio_factory.cpp
@@ -61,6 +62,9 @@ set(ALL_SRC
     src/cs_fw.cpp
     src/ailunce_radio.cpp
     src/ailunce_fw.cpp
+    src/yaesu_radio.cpp
+    src/yaesu_device.cpp
+    src/yaesu_fw.cpp
     src/fymodem.c
     src/rdt.cpp
     "${CMAKE_CURRENT_BINARY_DIR}/src/version.cpp"

--- a/include/radio_tool/device/yaesu_device.hpp
+++ b/include/radio_tool/device/yaesu_device.hpp
@@ -1,0 +1,44 @@
+/**
+ * This file is part of radio_tool.
+ * Copyright (c) 2022 v0l <radio_tool@v0l.io>
+ *
+ * radio_tool is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * radio_tool is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with radio_tool. If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <radio_tool/device/device.hpp>
+#include <radio_tool/h8sx/h8sx.hpp>
+
+#include <libusb-1.0/libusb.h>
+
+namespace radio_tool::device
+{
+	class YaesuDevice : public RadioDevice
+	{
+	public:
+		YaesuDevice(libusb_device_handle *h) : h8sx(h) {}
+
+		auto SetAddress(const uint32_t &) const -> void override;
+		auto Erase(const uint32_t &amount) const -> void override;
+		auto Write(const std::vector<uint8_t> &data) const -> void override;
+		auto Read(const uint16_t &size) const -> std::vector<uint8_t> override;
+		auto Status() const -> const std::string override;
+		auto GetH8SX() const -> const h8sx::H8SX &
+		{
+			return h8sx;
+		}
+    private:
+        radio_tool::h8sx::H8SX h8sx;
+	};
+} // namespace radio_tool::device

--- a/include/radio_tool/fw/fw_factory.hpp
+++ b/include/radio_tool/fw/fw_factory.hpp
@@ -21,6 +21,7 @@
 #include <radio_tool/fw/tyt_fw.hpp>
 #include <radio_tool/fw/cs_fw.hpp>
 #include <radio_tool/fw/ailunce_fw.hpp>
+#include <radio_tool/fw/yaesu_fw.hpp>
 
 #include <string>
 #include <memory>
@@ -52,7 +53,8 @@ namespace radio_tool::fw
     const std::vector<FirmwareSupportTest> AllFirmwareHandlers = {
         FirmwareSupportTest(TYTFW::SupportsFirmwareFile, TYTFW::SupportsRadioModel, TYTFW::Create),
         FirmwareSupportTest(CSFW::SupportsFirmwareFile, CSFW::SupportsRadioModel, CSFW::Create),
-        FirmwareSupportTest(AilunceFW::SupportsFirmwareFile, AilunceFW::SupportsRadioModel, AilunceFW::Create)
+        FirmwareSupportTest(AilunceFW::SupportsFirmwareFile, AilunceFW::SupportsRadioModel, AilunceFW::Create),
+        FirmwareSupportTest(YaesuFW::SupportsFirmwareFile, YaesuFW::SupportsRadioModel, YaesuFW::Create)
     };
 
     class FirmwareFactory

--- a/include/radio_tool/fw/yaesu_fw.hpp
+++ b/include/radio_tool/fw/yaesu_fw.hpp
@@ -1,0 +1,87 @@
+/**
+ * This file is part of radio_tool.
+ * Copyright (c) 2020 v0l <radio_tool@v0l.io>
+ * 
+ * radio_tool is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * radio_tool is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with radio_tool. If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <radio_tool/fw/fw.hpp>
+
+#include <fstream>
+#include <cstring>
+#include <sstream>
+#include <memory>
+#include <iomanip>
+
+namespace radio_tool::fw
+{
+    /**
+     * Class to store all config for each Yaesu radio model
+     */
+    class YaesuRadioConfig
+    {
+    public:
+        YaesuRadioConfig(const std::string &model)
+            : radio_model(model)
+        {
+        }
+
+        /**
+         * The model of the radio
+         */
+        const std::string radio_model;
+    };
+
+    class YaesuFW : public FirmwareSupport
+    {
+    public:
+        YaesuFW() {}
+
+        auto Read(const std::string &file) -> void override;
+        auto Write(const std::string &file) -> void override;
+        auto ToString() const -> std::string override;
+        auto Decrypt() -> void override;
+        auto Encrypt() -> void override;
+        auto SetRadioModel(const std::string&) -> void override;
+
+        /**
+         * @note This is not the "firmware_model" which exists in the firmware header
+         */
+        auto GetRadioModel() const -> const std::string override;
+
+
+        /**
+         * Tests a file if its a valid firmware file
+         */
+        static auto SupportsFirmwareFile(const std::string &file) -> bool;
+
+        /**
+         * Tests if a radio model is supported by this firmware handler
+         */
+        static auto SupportsRadioModel(const std::string &model) -> bool;
+
+        /**
+         * Create an instance of this class for the firmware factory
+         */
+        static auto Create() -> std::unique_ptr<FirmwareSupport>
+        {
+            return std::make_unique<YaesuFW>();
+        }
+
+    private:
+        std::string radio_model;
+    };
+
+} // namespace radio_tool::fw

--- a/include/radio_tool/h8sx/h8sx.hpp
+++ b/include/radio_tool/h8sx/h8sx.hpp
@@ -1,17 +1,17 @@
 /**
  * This file is part of radio_tool.
  * Copyright (c) 2020 v0l <radio_tool@v0l.io>
- * 
+ *
  * radio_tool is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * radio_tool is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with radio_tool. If not, see <https://www.gnu.org/licenses/>.
  */
@@ -27,18 +27,25 @@
 #include <libusb-1.0/libusb.h>
 #include <radio_tool/h8sx/h8sx_exception.hpp>
 
-#define CHECK_ERR(errstr)                                               \
-    do {                                                                \
-        if (err < LIBUSB_SUCCESS) {                                     \
-            std::string e = std::string(errstr) +                       \
-                            std::string(libusb_error_name(err));        \
-            throw radio_tool::h8sx::H8SXException(e);                   \
-        }                                                               \
-    } while(0)
-#define PACK __attribute__((__packed__))
+#define CHECK_ERR(errstr)                                        \
+    do                                                           \
+    {                                                            \
+        if (err < LIBUSB_SUCCESS)                                \
+        {                                                        \
+            std::string e = std::string(errstr) +                \
+                            std::string(libusb_error_name(err)); \
+            throw radio_tool::h8sx::H8SXException(e);            \
+        }                                                        \
+    } while (0)
 
-#define BULK_EP_IN   0x82
-#define BULK_EP_OUT  0x01
+#if defined(__GNUC__)
+#define PACK(__Declaration__) __Declaration__ __attribute__((__packed__))
+#elif defined(_MSC_VER)
+#define PACK(__Declaration__) __pragma(pack(push, 1)) __Declaration__ __pragma(pack(pop))
+#endif
+
+#define BULK_EP_IN 0x82
+#define BULK_EP_OUT 0x01
 #define BUF_SIZE 64 * 1024 // Max transfer size 64KB
 
 namespace radio_tool::h8sx
@@ -105,40 +112,40 @@ namespace radio_tool::h8sx
     };
 
     // Supported device inquiry response
-    struct PACK dev_inq_hdr_t {
+    PACK(struct dev_inq_hdr_t {
         uint8_t cmd = 0;
         uint8_t size = 0;
         uint8_t ndev = 0;
         uint8_t nchar = 0;
-        char code[4] = { 0 };
-    };
+        char code[4] = {0};
+    });
 
-    struct PACK dev_sel_t {
+    PACK(struct dev_sel_t {
         uint8_t cmd = 0;
         uint8_t size = 0;
-        char code[4] = { 0 };
+        char code[4] = {0};
         uint8_t sum = 0;
-    };
+    });
 
-    struct PACK prog_chunk_t {
+    PACK(struct prog_chunk_t {
         uint8_t cmd = static_cast<uint8_t>(H8SXCmd::PROGRAM_128B);
         uint32_t addr = 0;
-        uint8_t data[1024] = { 0 };
+        uint8_t data[1024] = {0};
         uint8_t sum = 0;
-    };
+    });
 
-    struct PACK prog_end_t {
+    PACK(struct prog_end_t {
         uint8_t cmd = static_cast<uint8_t>(H8SXCmd::PROGRAM_128B);
         uint32_t addr = 0xffffffff;
         uint8_t sum = 0xb4;
-    };
+    });
 
-    struct PACK sum_chk_t {
+    PACK(struct sum_chk_t {
         uint8_t cmd;
         uint8_t size;
         uint32_t chk;
         uint8_t sum;
-    };
+    });
 
     class H8SX
     {

--- a/include/radio_tool/h8sx/h8sx.hpp
+++ b/include/radio_tool/h8sx/h8sx.hpp
@@ -1,0 +1,176 @@
+/**
+ * This file is part of radio_tool.
+ * Copyright (c) 2020 v0l <radio_tool@v0l.io>
+ * 
+ * radio_tool is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * radio_tool is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with radio_tool. If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <stdint.h>
+#include <vector>
+#include <string>
+#include <sstream>
+#include <iomanip>
+#include <iostream>
+
+#include <libusb-1.0/libusb.h>
+#include <radio_tool/h8sx/h8sx_exception.hpp>
+
+#define CHECK_ERR(errstr)                                               \
+    do {                                                                \
+        if (err < LIBUSB_SUCCESS) {                                     \
+            std::string e = std::string(errstr) +                       \
+                            std::string(libusb_error_name(err));        \
+            throw radio_tool::h8sx::H8SXException(e);                   \
+        }                                                               \
+    } while(0)
+#define PACK __attribute__((__packed__))
+
+#define BULK_EP_IN   0x82
+#define BULK_EP_OUT  0x01
+#define BUF_SIZE 64 * 1024 // Max transfer size 64KB
+
+namespace radio_tool::h8sx
+{
+    enum class H8SXCmd : uint8_t
+    {
+        /*
+         * Begin the inquiry phase
+         */
+        BEGIN_INQUIRY = 0x55,
+
+        /*
+         * Inquiry regarding device codes
+         */
+        DEVICE_INQUIRY = 0x20,
+
+        /*
+         * Selection of device code
+         */
+        DEVICE_SELECT = 0x10,
+
+        /*
+         * Inquiry regarding numbers of clock modes
+         * and values of each mode
+         */
+        CLOCK_MODE_INQUIRY = 0x21,
+
+        /*
+         * Indication of the selected clock mode
+         */
+        CLOCK_MODE_SELECT = 0x11,
+
+        /*
+         * Inquiry regarding the unit of program data
+         */
+        PROG_UNIT_INQUIRY = 0x27,
+
+        /*
+         * Selection of new bit rate
+         */
+        BITRATE_SELECT = 0x3F,
+
+        /*
+         * Erasing of user MAT and user boot MAT, and
+         * entry to programming/erasing state
+         */
+        BEGIN_PROGRAMMING = 0x40,
+
+        /*
+         * Transfers the user MAT programming
+         * program
+         */
+        USER_MAT_SELECT = 0x43,
+
+        /*
+         * Programs 128 bytes of data
+         */
+        PROGRAM_128B = 0x50,
+
+        /*
+         * Checks the checksum of the user MAT
+         */
+        USER_MAT_CHECKSUM = 0x4B,
+    };
+
+    // Supported device inquiry response
+    struct PACK dev_inq_hdr_t {
+        uint8_t cmd = 0;
+        uint8_t size = 0;
+        uint8_t ndev = 0;
+        uint8_t nchar = 0;
+        char code[4] = { 0 };
+    };
+
+    struct PACK dev_sel_t {
+        uint8_t cmd = 0;
+        uint8_t size = 0;
+        char code[4] = { 0 };
+        uint8_t sum = 0;
+    };
+
+    struct PACK prog_chunk_t {
+        uint8_t cmd = static_cast<uint8_t>(H8SXCmd::PROGRAM_128B);
+        uint32_t addr = 0;
+        uint8_t data[1024] = { 0 };
+        uint8_t sum = 0;
+    };
+
+    struct PACK prog_end_t {
+        uint8_t cmd = static_cast<uint8_t>(H8SXCmd::PROGRAM_128B);
+        uint32_t addr = 0xffffffff;
+        uint8_t sum = 0xb4;
+    };
+
+    struct PACK sum_chk_t {
+        uint8_t cmd;
+        uint8_t size;
+        uint32_t chk;
+        uint8_t sum;
+    };
+
+    class H8SX
+    {
+    public:
+        H8SX(libusb_device_handle *device)
+            : timeout(5000), device(device) {}
+
+        auto Init() const -> void;
+        auto IdentifyDevice() -> std::string;
+        auto Download(const std::vector<uint8_t> &) const -> void;
+
+    private:
+        libusb_context *usb_ctx;
+
+        auto GetDeviceString(const libusb_device_descriptor &, libusb_device_handle *) const -> std::wstring;
+        auto Checksum(const uint8_t *data, const size_t len) const -> uint8_t;
+
+    protected:
+        const uint16_t timeout;
+        libusb_device_handle *device;
+        struct dev_inq_hdr_t *dir;
+
+        auto CheckDevice() const -> void;
+
+        /**
+         * Ensures the state is H8SX_IDLE or H8SX_DNLOAD_IDLE
+         */
+        auto InitDownload() const -> void;
+
+        /**
+         * Ensures the state is H8SX_IDLE or H8SX_DPLOAD_IDLE
+         */
+        auto InitUpload() const -> void;
+    };
+} // namespace radio_tool::h8sx

--- a/include/radio_tool/h8sx/h8sx_exception.hpp
+++ b/include/radio_tool/h8sx/h8sx_exception.hpp
@@ -1,0 +1,35 @@
+/**
+ * This file is part of radio_tool.
+ * Copyright (c) 2020 v0l <radio_tool@v0l.io>
+ * 
+ * radio_tool is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * radio_tool is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with radio_tool. If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <exception>
+#include <string>
+
+namespace radio_tool::h8sx {
+    class H8SXException : public std::exception {
+    public:
+        H8SXException(const std::string& str) 
+            : msg(str) { }
+
+        auto what() const noexcept -> const char* {
+            return msg.c_str();
+        }
+    private:
+        const std::string msg;
+    };
+}

--- a/include/radio_tool/radio/yaesu_radio.hpp
+++ b/include/radio_tool/radio/yaesu_radio.hpp
@@ -1,0 +1,59 @@
+/**
+ * This file is part of radio_tool.
+ * Copyright (c) 2022 v0l <radio_tool@v0l.io>
+ * 
+ * radio_tool is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * radio_tool is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with radio_tool. If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <radio_tool/radio/radio.hpp>
+#include <radio_tool/device/yaesu_device.hpp>
+
+#include <functional>
+#include <libusb-1.0/libusb.h>
+
+namespace radio_tool::radio
+{
+    class YaesuRadio : public RadioOperations
+    {
+    public:
+        static const auto VID = 0x045b;
+        static const auto PID = 0x0025;
+
+        YaesuRadio(libusb_device_handle* h)
+            : device(h) {}
+
+        auto WriteFirmware(const std::string &file) const -> void override;
+        auto ToString() const -> const std::string override;
+
+        static auto SupportsDevice(const libusb_device_descriptor &dev) -> bool
+        {
+            return dev.idVendor == VID && dev.idProduct == PID;
+        }
+
+        /**
+         * Get the handler used to communicate with this device
+         */
+        auto GetDevice() const -> const device::YaesuDevice* override
+        {
+            return &device;
+        }
+
+        static auto Create(libusb_device_handle* h) -> const YaesuRadio* {
+            return new YaesuRadio(h);
+        }
+    private:
+        const device::YaesuDevice device;
+    };
+} // namespace radio_tool::radio

--- a/src/h8sx.cpp
+++ b/src/h8sx.cpp
@@ -1,0 +1,412 @@
+/**
+ * This file is part of radio_tool.
+ * Copyright (c) 2020 v0l <radio_tool@v0l.io>
+ * 
+ * radio_tool is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * radio_tool is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with radio_tool. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include <radio_tool/h8sx/h8sx.hpp>
+
+#include <algorithm>
+#include <chrono>
+#include <cstring>
+#include <exception>
+#include <thread>
+
+using namespace radio_tool::h8sx;
+
+auto H8SX::IdentifyDevice() -> std::string
+{
+    int err = 0;
+    int transferred = 0, received = 0;
+    uint8_t buf[BUF_SIZE];
+
+    // First command     0x55 -> Begin inquiry phase
+    uint8_t cmd = static_cast<uint8_t>(H8SXCmd::BEGIN_INQUIRY);
+    err = libusb_bulk_transfer(device,
+                               BULK_EP_OUT,
+                               &cmd,
+                               1,
+                               &transferred,
+                               0);
+    CHECK_ERR("cannot begin inquiry phase!");
+
+    // Expected response 0xE6 <- (ACK)
+    err = libusb_bulk_transfer(device,
+                               BULK_EP_IN,
+                               buf,
+                               sizeof(buf),
+                               &received,
+                               0);
+    CHECK_ERR("I/O error!");
+    if (buf[0] != 0xE6)
+        err = -1;
+    CHECK_ERR("wrong response from radio!");
+
+    // Second command     0x20 -> Supported Device Inquiry
+    cmd = static_cast<uint8_t>(H8SXCmd::DEVICE_INQUIRY);
+    err = libusb_bulk_transfer(device,
+                               BULK_EP_OUT,
+                               &cmd,
+                               1,
+                               &transferred,
+                               0);
+    CHECK_ERR("I/O error!");
+
+    // Expected response  <- Supported Device Response
+    err = libusb_bulk_transfer(device,
+                               BULK_EP_IN,
+                               buf,
+                               sizeof(buf),
+                               &received,
+                               0);
+    // Checksum
+    err = libusb_bulk_transfer(device,
+                               BULK_EP_IN,
+                               buf,
+                               1,
+                               &received,
+                               0);
+    CHECK_ERR("error in device selection!");
+    dir = (struct dev_inq_hdr_t *) buf;
+    // TODO: Validate checksum
+    buf[sizeof(struct dev_inq_hdr_t) + dir->nchar] = '\0';
+
+    // Return device identifier
+    std::ostringstream dev_str;
+    dev_str << dir->code[0]
+       << dir->code[1]
+       << dir->code[2]
+       << dir->code[3]
+       << "-"
+       << buf + sizeof(struct dev_inq_hdr_t);
+    return dev_str.str();
+}
+
+auto H8SX::Download(const std::vector<uint8_t>& data) const -> void
+{
+    int err = 0;
+    int transferred = 0, received = 0;
+    uint8_t buf[BUF_SIZE];
+
+    InitDownload();
+
+    // 128-Byte Programming 0x50 ->
+    struct prog_chunk_t c = { };
+    uint8_t cmd = static_cast<uint8_t>(H8SXCmd::PROGRAM_128B);
+    uint32_t bin_sum = 0;
+    for(std::vector<uint8_t>::size_type i = 0; i < data.size() / 1024; i++) {
+        c.addr = __builtin_bswap32(i * 1024);
+        std::copy(data.begin() + i * 1024, data.begin() + (i + 1) * 1024, c.data);
+        bin_sum += Checksum((uint8_t *)&(c.data), 1024);
+        c.sum = Checksum((uint8_t *) &c, sizeof(c) - 1);
+        err = libusb_bulk_transfer(device,
+                                   BULK_EP_OUT,
+                                   (uint8_t *) &c,
+                                   sizeof(c),
+                                   &transferred,
+                                   0);
+        CHECK_ERR("error during programming!");
+        // Expected response 0x06 <- (ACK)
+        err = libusb_bulk_transfer(device,
+                                   BULK_EP_IN,
+                                   buf,
+                                   sizeof(buf),
+                                   &received,
+                                   0);
+        CHECK_ERR("error during programming!");
+        if (buf[0] != 0x06)
+            err = -1;
+        CHECK_ERR("error during programming!");
+    }
+
+    // Send 1024 and then last 6
+
+    // Stop Programming Operation
+    struct prog_end_t e = { };
+    err = libusb_bulk_transfer(device,
+                               BULK_EP_OUT,
+                               (uint8_t *) &e,
+                               sizeof(e),
+                               &transferred,
+                               0);
+    CHECK_ERR("error during programming stop!");
+    // Expected response 0x06 <- (ACK)
+    err = libusb_bulk_transfer(device,
+                               BULK_EP_IN,
+                               buf,
+                               sizeof(buf),
+                               &received,
+                               0);
+    CHECK_ERR("error during programming stop!");
+    if (buf[0] != 0x06)
+        err = -1;
+    CHECK_ERR("error during programming stop!");
+
+    // User MAT Sum Check 0x4B ->
+    cmd = static_cast<uint8_t>(H8SXCmd::USER_MAT_CHECKSUM);
+    err = libusb_bulk_transfer(device,
+                               BULK_EP_OUT,
+                               &cmd,
+                               1,
+                               &transferred,
+                               0);
+    CHECK_ERR("error during user MAT sum check!");
+    err = libusb_bulk_transfer(device,
+                               BULK_EP_IN,
+                               buf,
+                               sizeof(buf),
+                               &received,
+                               0);
+    CHECK_ERR("error during user MAT sum check!");
+    struct sum_chk_t *chk = (struct sum_chk_t *) buf;
+    if (chk->cmd != 0x5B &&
+        chk->size != 4 &&
+        chk->sum != Checksum((uint8_t *) chk, sizeof(struct sum_chk_t) - 1) &&
+        __builtin_bswap32(chk->chk) != bin_sum)
+        err = -1;
+    CHECK_ERR("error during user MAT sum check!");
+}
+
+auto H8SX::InitDownload() const -> void
+{
+    int err = 0;
+    int transferred = 0, received = 0;
+    uint8_t buf[BUF_SIZE];
+    uint8_t sum = 0;
+
+    // Select device to flash
+    struct dev_sel_t sel = { 0 };
+    sel.cmd = static_cast<uint8_t>(H8SXCmd::DEVICE_SELECT);
+    sel.size = 4;
+    for (int i = 0; i < 4; i++)
+        sel.code[i] = dir->code[i];
+    sel.sum = Checksum((uint8_t *) &sel, sizeof(sel) - 1);
+    err = libusb_bulk_transfer(device,
+                               BULK_EP_OUT,
+                               (uint8_t *) &sel,
+                               sizeof(sel),
+                               &transferred,
+                               0);
+    CHECK_ERR("error in device selection!");
+    // Expected response 0x06 <- (ACK)
+    err = libusb_bulk_transfer(device,
+                               BULK_EP_IN,
+                               buf,
+                               sizeof(buf),
+                               &received,
+                               0);
+    CHECK_ERR("error in device selection!");
+    if (buf[0] != 0x06)
+        err = -1;
+    CHECK_ERR("error in device selection!");
+
+    // 0x21 -> Clock Mode Inquiry
+    uint8_t cmd = static_cast<uint8_t>(H8SXCmd::CLOCK_MODE_INQUIRY);
+    err = libusb_bulk_transfer(device,
+                               BULK_EP_OUT,
+                               &cmd,
+                               1,
+                               &transferred,
+                               0);
+    CHECK_ERR("error during clock mode inquiry!");
+    err = libusb_bulk_transfer(device,
+                               BULK_EP_IN,
+                               (uint8_t *) &buf,
+                               sizeof(buf),
+                               &received,
+                               0);
+    CHECK_ERR("error during clock mode inquiry!");
+    // Checksum
+    err = libusb_bulk_transfer(device,
+                               BULK_EP_IN,
+                               &sum,
+                               1,
+                               &received,
+                               0);
+
+    // 0x11 -> Clock Mode Selection
+    uint8_t csel[] = { 0x11, 0x01, 0x01, 0xed };
+    err = libusb_bulk_transfer(device,
+                               BULK_EP_OUT,
+                               (uint8_t *) &csel,
+                               sizeof(csel),
+                               &transferred,
+                               0);
+    CHECK_ERR("error during clock mode selection!");
+    // Expected response 0x06 <- (ACK)
+    err = libusb_bulk_transfer(device,
+                               BULK_EP_IN,
+                               buf,
+                               sizeof(buf),
+                               &received,
+                               0);
+    CHECK_ERR("error in clock mode selection!");
+    if (buf[0] != 0x06)
+        err = -1;
+    CHECK_ERR("error in clock mode selection!");
+
+    // 0x27 -> Programming Unit Inquiry
+    cmd = static_cast<uint8_t>(H8SXCmd::PROG_UNIT_INQUIRY);
+    err = libusb_bulk_transfer(device,
+                               BULK_EP_OUT,
+                               &cmd,
+                               1,
+                               &transferred,
+                               0);
+    CHECK_ERR("error during programming mode inquiry!");
+    err = libusb_bulk_transfer(device,
+                               BULK_EP_IN,
+                               (uint8_t *) &buf,
+                               sizeof(buf),
+                               &received,
+                               0);
+    CHECK_ERR("error during programming mode inquiry!");
+    // Checksum
+    err = libusb_bulk_transfer(device,
+                               BULK_EP_IN,
+                               &sum,
+                               1,
+                               &received,
+                               0);
+
+    // 0x3F -> New Bit-Rate Selection
+    uint8_t bsel[] = { 0x3f, 0x07, 0x04, 0x80, 0x06, 0x40,
+                       0x02, 0x01, 0x01, 0xec };
+    err = libusb_bulk_transfer(device,
+                               BULK_EP_OUT,
+                               (uint8_t *) &bsel,
+                               sizeof(bsel),
+                               &transferred,
+                               0);
+    CHECK_ERR("error during bit rate selection!");
+    // Expected response 0x06 <- (ACK)
+    err = libusb_bulk_transfer(device,
+                               BULK_EP_IN,
+                               buf,
+                               sizeof(buf),
+                               &received,
+                               0);
+    CHECK_ERR("error during bit rate selection!");
+    if (buf[0] != 0x06)
+        err = -1;
+    CHECK_ERR("error during bit rate selection!");
+    // Bit rate confirmation 0x06 ->
+    cmd = 0x06;
+    err = libusb_bulk_transfer(device,
+                               BULK_EP_OUT,
+                               &cmd,
+                               1,
+                               &transferred,
+                               0);
+    CHECK_ERR("error during bit rate confirmation!");
+    // Expected response 0x06 <- (ACK)
+    err = libusb_bulk_transfer(device,
+                               BULK_EP_IN,
+                               buf,
+                               sizeof(buf),
+                               &received,
+                               0);
+    CHECK_ERR("error during bit rate confirmation!");
+    if (buf[0] != 0x06)
+        err = -1;
+    CHECK_ERR("error during bit rate confirmation!");
+
+    // Transition to Programming/Erasing State 0x40 ->
+    cmd = static_cast<uint8_t>(H8SXCmd::BEGIN_PROGRAMMING);
+    err = libusb_bulk_transfer(device,
+                               BULK_EP_OUT,
+                               &cmd,
+                               1,
+                               &transferred,
+                               0);
+    CHECK_ERR("error during transition to programming state!");
+    // Expected response 0x06 <- (ACK)
+    err = libusb_bulk_transfer(device,
+                               BULK_EP_IN,
+                               buf,
+                               sizeof(buf),
+                               &received,
+                               0);
+    CHECK_ERR("error during transition to programming state!");
+    if (buf[0] != 0x06)
+        err = -1;
+    CHECK_ERR("error during transition to programming state!");
+
+    // User MAT Programming Selection 0x43 ->
+    cmd = static_cast<uint8_t>(H8SXCmd::USER_MAT_SELECT);
+    err = libusb_bulk_transfer(device,
+                               BULK_EP_OUT,
+                               &cmd,
+                               1,
+                               &transferred,
+                               0);
+    CHECK_ERR("error during user MAT programming selection!");
+    // Expected response 0x06 <- (ACK)
+    err = libusb_bulk_transfer(device,
+                               BULK_EP_IN,
+                               buf,
+                               sizeof(buf),
+                               &received,
+                               0);
+    CHECK_ERR("error during user MAT programming selection!");
+    if (buf[0] != 0x06)
+        err = -1;
+    CHECK_ERR("error during user MAT programming selection!");
+}
+
+auto H8SX::Init() const -> void
+{
+    int err = 0;
+
+    // Reset device
+	err = libusb_reset_device(device);
+    CHECK_ERR("cannot reset device!");
+
+    // Unset auto kernel detach
+    err = libusb_set_auto_detach_kernel_driver(device, 0);
+    CHECK_ERR("cannot unset auto-detach!");
+
+    // Detach kernel interface
+    if (libusb_kernel_driver_active(device, 0)) {
+        err = libusb_detach_kernel_driver(device, 0);
+        CHECK_ERR("cannot detach kernel!");
+    }
+
+    // Set configuration
+    err = libusb_set_configuration(device, 1);
+    CHECK_ERR("cannot set configuration!");
+
+    // Claim device
+    err = libusb_claim_interface(device, 0);
+    CHECK_ERR("cannot claim interface!");
+
+}
+
+auto H8SX::CheckDevice() const -> void
+{
+    if (this->device == nullptr)
+        throw std::runtime_error("Device is not opened");
+}
+
+auto H8SX::Checksum(const uint8_t *data, size_t len) const -> uint8_t
+{
+    uint8_t sum = 0;
+    for (size_t i = 0; i < len; i++) {
+        sum += data[i];
+    }
+    sum = ~sum;
+    sum++;
+    return sum;
+}
+

--- a/src/h8sx.cpp
+++ b/src/h8sx.cpp
@@ -23,10 +23,9 @@
 #include <exception>
 #include <thread>
 
-/* Define byte-swap functions, using fast processor-native built-ins where possible */
-#if defined(_MSC_VER) // needs to be first because msvc doesn't short-circuit after failing defined(__has_builtin)
+#if defined(_MSC_VER)
 #define bswap32(x) _byteswap_ulong((x))
-#elif (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8)
+#else
 #define bswap32(x) __builtin_bswap32((x))
 #endif
 

--- a/src/yaesu_device.cpp
+++ b/src/yaesu_device.cpp
@@ -1,0 +1,36 @@
+/**
+ * This file is part of radio_tool.
+ * Copyright (c) 2020 v0l <radio_tool@v0l.io>
+ *
+ * radio_tool is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * radio_tool is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with radio_tool. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include <radio_tool/device/yaesu_device.hpp>
+
+using namespace radio_tool::device;
+
+auto YaesuDevice::SetAddress(const uint32_t &) const -> void { }
+auto YaesuDevice::Erase(const uint32_t &) const -> void { }
+auto YaesuDevice::Read(const uint16_t &) const -> std::vector<uint8_t>
+{
+    return { 0 };
+}
+auto YaesuDevice::Status() const -> const std::string
+{
+    return "";
+}
+
+auto YaesuDevice::Write(const std::vector<uint8_t>& data) const -> void
+{
+	this->h8sx.Download(data);
+}

--- a/src/yaesu_fw.cpp
+++ b/src/yaesu_fw.cpp
@@ -20,30 +20,30 @@
 
 using namespace radio_tool::fw;
 
-auto YaesuFW::Read(const std::string& file) -> void
+auto YaesuFW::Read(const std::string &file) -> void
 {
 	auto i = std::ifstream(file, std::ios_base::binary);
 	if (i.is_open())
 	{
-        // Compute binary file size
+		// Compute binary file size
 		i.seekg(0, std::ios_base::end);
-        auto binarySize = i.tellg();
+		auto binarySize = i.tellg();
 		i.seekg(0);
 
-        // Read binary
+		// Read binary
 		data.resize(binarySize);
-		i.read((char*)data.data(), binarySize);
+		i.read((char *)data.data(), binarySize);
 	}
 	i.close();
 }
 
-auto YaesuFW::Write(const std::string& file) -> void
+auto YaesuFW::Write(const std::string &file) -> void
 {
 	std::ofstream fout(file, std::ios_base::binary);
 	if (fout.is_open())
 	{
-		//write firmware data
-		fout.write((char*)data.data(), data.size());
+		// write firmware data
+		fout.write((char *)data.data(), data.size());
 		fout.close();
 	}
 }
@@ -53,22 +53,25 @@ auto YaesuFW::ToString() const -> std::string
 	std::stringstream out;
 	out << "== Yaesu Firmware == " << std::endl
 		<< "Size:  " << std::fixed << std::setprecision(2)
-        << (data.size() / 1024.0) << " KiB" << std::endl;
+		<< (data.size() / 1024.0) << " KiB" << std::endl;
 	return out.str();
 }
 
-auto YaesuFW::Decrypt() -> void { }
-auto YaesuFW::Encrypt() -> void { }
-auto YaesuFW::SetRadioModel(const std::string&) -> void { }
-auto YaesuFW::GetRadioModel() const -> const std::string { }
+auto YaesuFW::Decrypt() -> void {}
+auto YaesuFW::Encrypt() -> void {}
+auto YaesuFW::SetRadioModel(const std::string &) -> void {}
+auto YaesuFW::GetRadioModel() const -> const std::string
+{
+	return "Unknown";
+}
 
-auto YaesuFW::SupportsFirmwareFile(const std::string& file) -> bool
+auto YaesuFW::SupportsFirmwareFile(const std::string &file) -> bool
 {
 	std::ifstream i;
 	i.open(file, i.binary);
 	if (i.is_open())
 	{
-        return true;
+		return true;
 	}
 	else
 	{
@@ -76,7 +79,7 @@ auto YaesuFW::SupportsFirmwareFile(const std::string& file) -> bool
 	}
 }
 
-auto YaesuFW::SupportsRadioModel(const std::string& model) -> bool
+auto YaesuFW::SupportsRadioModel(const std::string &model) -> bool
 {
-    return true;
+	return true;
 }

--- a/src/yaesu_fw.cpp
+++ b/src/yaesu_fw.cpp
@@ -1,0 +1,82 @@
+/**
+ * This file is part of radio_tool.
+ * Copyright (c) 2020 v0l <radio_tool@v0l.io>
+ *
+ * radio_tool is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * radio_tool is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with radio_tool. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include <radio_tool/fw/yaesu_fw.hpp>
+#include <radio_tool/util.hpp>
+
+using namespace radio_tool::fw;
+
+auto YaesuFW::Read(const std::string& file) -> void
+{
+	auto i = std::ifstream(file, std::ios_base::binary);
+	if (i.is_open())
+	{
+        // Compute binary file size
+		i.seekg(0, std::ios_base::end);
+        auto binarySize = i.tellg();
+		i.seekg(0);
+
+        // Read binary
+		data.resize(binarySize);
+		i.read((char*)data.data(), binarySize);
+	}
+	i.close();
+}
+
+auto YaesuFW::Write(const std::string& file) -> void
+{
+	std::ofstream fout(file, std::ios_base::binary);
+	if (fout.is_open())
+	{
+		//write firmware data
+		fout.write((char*)data.data(), data.size());
+		fout.close();
+	}
+}
+
+auto YaesuFW::ToString() const -> std::string
+{
+	std::stringstream out;
+	out << "== Yaesu Firmware == " << std::endl
+		<< "Size:  " << std::fixed << std::setprecision(2)
+        << (data.size() / 1024.0) << " KiB" << std::endl;
+	return out.str();
+}
+
+auto YaesuFW::Decrypt() -> void { }
+auto YaesuFW::Encrypt() -> void { }
+auto YaesuFW::SetRadioModel(const std::string&) -> void { }
+auto YaesuFW::GetRadioModel() const -> const std::string { }
+
+auto YaesuFW::SupportsFirmwareFile(const std::string& file) -> bool
+{
+	std::ifstream i;
+	i.open(file, i.binary);
+	if (i.is_open())
+	{
+        return true;
+	}
+	else
+	{
+		throw std::runtime_error("Can't open firmware file");
+	}
+}
+
+auto YaesuFW::SupportsRadioModel(const std::string& model) -> bool
+{
+    return true;
+}

--- a/src/yaesu_radio.cpp
+++ b/src/yaesu_radio.cpp
@@ -1,0 +1,53 @@
+/**
+ * This file is part of radio_tool.
+ * Copyright (c) 2022 v0l <radio_tool@v0l.io>
+ *                    Niccolò Izzo <iu2kin@openrtx.org>
+ *
+ * radio_tool is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * radio_tool is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with radio_tool. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include <radio_tool/radio/yaesu_radio.hpp>
+#include <radio_tool/fw/yaesu_fw.hpp>
+#include <radio_tool/util/flash.hpp>
+
+#include <math.h>
+#include <iomanip>
+#include <iostream>
+#include <vector>
+
+using namespace radio_tool::radio;
+
+auto YaesuRadio::ToString() const -> const std::string
+{
+	std::stringstream out;
+
+	auto h8sx = device.GetH8SX();
+	auto model = h8sx.IdentifyDevice();
+
+	out << "== Yaesu Radio Info ==" << std::endl
+		<< "Radio: " << model << std::endl;
+
+	return out.str();
+}
+
+auto YaesuRadio::WriteFirmware(const std::string& file) const -> void
+{
+	auto fw = fw::YaesuFW();
+	fw.Read(file);
+
+	auto h8sx = device.GetH8SX();
+	auto to_write = fw.GetData();
+    h8sx.Init();
+    h8sx.IdentifyDevice();
+	h8sx.Download(to_write);
+}


### PR DESCRIPTION
Add a new target radio, Yaesu FT-70D, which is flashed via USB through the proprietary protocol of its Hitachi H8SX Microcontroller BootROM.
The new target accepts raw binaries only, therefore the firmware compatibility checks are stubbed.
Please review it and let me know if there is anything to change.

Messed something up in #18 