### PR TITLE
Additional includes required by GCC 12.2

### DIFF
--- a/include/radio_tool/fw/tyt_fw_sgl.hpp
+++ b/include/radio_tool/fw/tyt_fw_sgl.hpp
@@ -24,6 +24,8 @@
 #include <cstring>
 #include <sstream>
 #include <iomanip>
+#include <algorithm>
+#include <memory>
 
 namespace radio_tool::fw
 {


### PR DESCRIPTION
I was unable to build with GCC 12.2 without these includes, relating to the use of std::find_if and std::unique_ptr.