### PR TITLE
Fix Fw Write for SGL radios

### DIFF
--- a/include/radio_tool/hid/tyt_hid.hpp
+++ b/include/radio_tool/hid/tyt_hid.hpp
@@ -91,9 +91,9 @@ namespace radio_tool::hid
 
 		auto Setup() -> void;
 
-		auto SendCommand(const tyt::Command& cmd) -> void;
-		auto SendCommand(const std::vector<uint8_t>& cmd) -> void;
-		auto SendCommand(const std::vector<uint8_t>& cmd, const uint8_t& size, const uint8_t& fill) -> void;
+		auto SendCommand(const tyt::Command& cmd) -> tyt::Command;
+		auto SendCommand(const std::vector<uint8_t>& cmd) -> tyt::Command;
+		auto SendCommand(const std::vector<uint8_t>& cmd, const uint8_t& size, const uint8_t& fill) -> tyt::Command;
 
 		auto SendCommandAndOk(const tyt::Command& cmd) -> void;
 		auto SendCommandAndOk(const std::vector<uint8_t>& cmd) -> void;

--- a/include/radio_tool/util.hpp
+++ b/include/radio_tool/util.hpp
@@ -26,6 +26,14 @@
 #include <iterator>
 #include <iomanip>
 
+#if defined(_MSC_VER)
+#define bswap32(x) _byteswap_ulong((x))
+#define bswap16(x) _byteswap_ushort((x))
+#else
+#define bswap32(x) __builtin_bswap32((x))
+#define bswap16(x) __builtin_bswap16((x))
+#endif
+
 namespace radio_tool
 {
 	constexpr auto kiB = (1UL << 10);

--- a/src/h8sx.cpp
+++ b/src/h8sx.cpp
@@ -22,12 +22,7 @@
 #include <cstring>
 #include <exception>
 #include <thread>
-
-#if defined(_MSC_VER)
-#define bswap32(x) _byteswap_ulong((x))
-#else
-#define bswap32(x) __builtin_bswap32((x))
-#endif
+#include "radio_tool/util.hpp"
 
 using namespace radio_tool::h8sx;
 

--- a/src/usb_radio_factory.cpp
+++ b/src/usb_radio_factory.cpp
@@ -93,6 +93,12 @@ auto USBRadioFactory::ListDevices(const uint16_t &idx_offset) const -> const std
 								mfg = L"Yaesu";
 								prd = L"FT-70D";
 							}
+                            // Raddioddity & others
+                            else if (desc.idVendor == hid::TYTHID::VID && desc.idProduct == hid::TYTHID::PID)
+                            {
+                                mfg = L"TYT";
+                                prd = L"SGL";
+                            }
 							else
 							{
 								mfg = GetDeviceString(desc.iManufacturer, h);


### PR DESCRIPTION
Fixed the firmware upload for TYT SGL radios.
The USB callback code wasn't working for me so I made it synchronous. The wrapping of the firmware isn't working yet.
I've tested it only with the Radioddity GD77 flashing OpenRTX on Fedora, not sure if it works on Windows.

Please review it and let me know if there is anything to change.
